### PR TITLE
Replacement of PythonLevenshtein with pyxDamerauLevenshtein

### DIFF
--- a/fuzzyset/__init__.py
+++ b/fuzzyset/__init__.py
@@ -2,7 +2,7 @@ import re
 import math
 import operator
 import collections
-import Levenshtein
+import pyxDamerauLevenshtein
 
 __version__ = (0, 0, 18)
 
@@ -98,7 +98,7 @@ class FuzzySet(object):
 
 
 def _distance(str1, str2):
-    distance = Levenshtein.distance(str1, str2)
+    distance = pyxdameraulevenshtein.damerau_levenshtein_distance(str1, str2)
     if len(str1) > len(str2):
         return 1 - float(distance) / len(str1)
     else:

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     url = "https://github.com/axiak/fuzzyset/",
     packages=['fuzzyset'],
     long_description=read('README.rst'),
-    install_requires=['python-levenshtein', 'texttable'],
+    install_requires=['pyxDamerauLevenshtein', 'texttable'],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
The PythonLevenshtein Library is distributed under GNU General Public License v2 which makes the use of fuzzyset problematic even though fuzzyset is distributed under BSD License.

It makes more sense to use pyxDamerauLevenshtein which is distributed under BSD License.