### PR TITLE
Bug fix: equality -> inequality for cFuzzySet cosine sim threshold

### DIFF
--- a/fuzzyset/cfuzzyset.pyx
+++ b/fuzzyset/cfuzzyset.pyx
@@ -161,7 +161,7 @@ cdef class cFuzzySet:
             score_threshold = results[0][0] * self.rel_sim_cutoff
             return [(score / norm, self.exact_set[value])
                     for score, value in results
-                    if score == score_threshold]
+                    if score >= score_threshold]
 
     def __len__(self):
         return len(self.exact_set)


### PR DESCRIPTION
Hi Michael, I'm using your package for as part of a fuzzy search solution in a larger project and I'd really appreciate it if you could merge this simple, 1-character bug fix so that I can use the faster Cython implementation.